### PR TITLE
Do not override init

### DIFF
--- a/addon/components/cloudinary-direct-file.js
+++ b/addon/components/cloudinary-direct-file.js
@@ -23,10 +23,7 @@ export default Ember.Component.extend({
   acceptFileTypes: /(\.|\/)(gif|jpe?g|png|bmp|ico)$/i,
   maxFileSize: 50000000,
 
-  // Fetch signature
-  init() {
-    this._super(...arguments);
-
+  fetchSignature: Ember.on('init', function() {
     if (!this.get('signatureEndpoint')) {
       Ember.Logger.error('`signatureEndpoint` parameter must be specified on cloudinary-direct-file component.');
     }
@@ -34,7 +31,7 @@ export default Ember.Component.extend({
     Ember.$.get(this.get('signatureEndpoint'), { timestamp: Date.now() / 1000 }).done((response) => {
       Ember.run(() => { this.set('data-form-data', JSON.stringify(response)); });
     });
-  },
+  }),
 
   didSetData: Ember.observer('data-form-data', function() {
     Ember.run.next(this, function() {


### PR DESCRIPTION
2 reasons:
- It is a best practice: https://dockyard.com/blog/2014/04/28/dont-override-init
- It prevents overriding init in case you want to add data to cloudinary signature
