### PR TITLE
Feat/allow file validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,37 @@ This component will sign and upload a file directly to Cloudinary from the brows
 
 Set *signatureEndpoint* to the API endpoint that signs your cloudinary direct upload requests.
 
-You can also set an action when the file is done uploading:
+You can also set an action for different events. For example when the file is done uploading:
 
 ```javascript
 {{cloudinary-direct-file signatureEndpoint='/sign_upload' onUploadDone=(action 'showThumbnail')}}
 ```
 
+#### Options
+option | default  | Info
+------ | ---- |  ----
+name | 'file' |  Name of the input
+multiple | false | True if you want to upload more than one file
+accept | 'image/jpeg,image/gif,image/png' | Files types allowed in the input type file
+style | Ember.String.htmlSafe("") | Component style
+signatureEndpoint | null | Signs your cloudinary direct upload requests
+disableImageResize | null | -
+imageMaxWidth | 10000000 | Image max width
+imageMaxHeight | 10000000 | Image max height
+acceptFileTypes | [Regex with image extensions] | Files extension allowed (checked by code)
+maxFileSize | 50000000 | Max File Size
+loadImageMaxFileSize | 50000000 | Load Image Max File Size
+
+#### Events
+Event | Info
+------ | ---- 
+onUploadDone | File uploaded
+fileProgress | File progress
+allFileProgress | More than one file progress
+onUploadStart | Upload Starts
+onUploadStop | Upload Stops
+onUploadFail | Upload Fails
+onUploadAlways | Upload Always
 
 ## Running Tests ##
 

--- a/addon/components/cloudinary-direct-file.js
+++ b/addon/components/cloudinary-direct-file.js
@@ -73,6 +73,10 @@ export default Ember.Component.extend({
       this.sendAction('onUploadStop', e, data);
     });
 
+    this.$().bind('cloudinaryfail', (e, data) => {
+      this.sendAction('onUploadFail', e, data);
+    });
+
     this.$().bind('fileuploadprocessfail', (e, data) => {
       this.sendAction('onUploadFail', e, data);
     });

--- a/addon/components/cloudinary-direct-file.js
+++ b/addon/components/cloudinary-direct-file.js
@@ -4,14 +4,16 @@ export default Ember.Component.extend({
   tagName: 'input',
   classNames: ['cloudinary-fileupload'],
 
-  attributeBindings: ['name', 'type', 'data-cloudinary-field', 'data-form-data', 'multiple'],
+  attributeBindings: ['name', 'type', 'data-cloudinary-field', 'data-form-data', 'multiple', 'style', 'accept'],
 
   // Attributes
   name: 'file',
   type: 'file',
-  multiple: true,
+  multiple: false,
   fieldName: null,
   'data-cloudinary-field': Ember.computed.alias('fieldName'),
+  accept: 'image/jpeg,image/gif,image/png',
+  style: Ember.String.htmlSafe(""),
 
   // Endpoint
   signatureEndpoint: null,
@@ -22,6 +24,7 @@ export default Ember.Component.extend({
   imageMaxHeight: 10000000,
   acceptFileTypes: /(\.|\/)(gif|jpe?g|png|bmp|ico)$/i,
   maxFileSize: 50000000,
+  loadImageMaxFileSize: 50000000,
 
   // Fetch signature
   init() {
@@ -43,7 +46,8 @@ export default Ember.Component.extend({
         imageMaxWidth:      this.get('imageMaxWidth'),
         imageMaxHeight:     this.get('imageMaxHeight'),
         acceptFileTypes:    this.get('acceptFileTypes'),
-        maxFileSize:        this.get('maxFileSize')
+        maxFileSize:        this.get('maxFileSize'),
+        loadImageMaxFileSize: this.get('loadImageMaxFileSize')
       });
     });
   }),
@@ -69,7 +73,7 @@ export default Ember.Component.extend({
       this.sendAction('onUploadStop', e, data);
     });
 
-    this.$().bind('cloudinaryfail', (e, data) => {
+    this.$().bind('fileuploadprocessfail', (e, data) => {
       this.sendAction('onUploadFail', e, data);
     });
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ module.exports = {
     app.import(app.bowerDirectory + '/blueimp-file-upload/js/vendor/jquery.ui.widget.js');
     app.import(app.bowerDirectory + '/blueimp-file-upload/js/jquery.iframe-transport.js');
     app.import(app.bowerDirectory + '/blueimp-file-upload/js/jquery.fileupload.js');
+    app.import(app.bowerDirectory + '/blueimp-file-upload/js/jquery.fileupload-process.js');
+    app.import(app.bowerDirectory + '/blueimp-file-upload/js/jquery.fileupload-validate.js');
     app.import(app.bowerDirectory + '/cloudinary-jquery-file-upload/cloudinary-jquery-file-upload.js');
   }
 };


### PR DESCRIPTION
This PR is an evolution of [waelbeso one](https://github.com/mileszim/ember-cli-cloudinary/pull/5) it includes:

-Suggested @mileszim changes
-Updated README with options & events.
-Added new useful props (style & accept)
-Catch the jQuery event 'fileuploadprocessfail'. @mileszim The [cloudinary library](https://github.com/cloudinary/cloudinary_js/blob/6eac8e5233e6c04e772dcc0f991d28ae4d668c2a/src/jquery-file-upload.coffee#L106-L107) does not catch this event