### PR TITLE
accept maxChunkSize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ imageMaxHeight | 10000000 | Image max height
 acceptFileTypes | [Regex with image extensions] | Files extension allowed (checked by code)
 maxFileSize | 50000000 | Max File Size
 loadImageMaxFileSize | 50000000 | Load Image Max File Size
+maxChunkSize | null | Required for chunked upload of bigger files
 
 #### Events
 Event | Info
------- | ---- 
+------ | ----
 onUploadDone | File uploaded
 fileProgress | File progress
 allFileProgress | More than one file progress

--- a/addon/components/cloudinary-direct-file.js
+++ b/addon/components/cloudinary-direct-file.js
@@ -25,7 +25,7 @@ export default Ember.Component.extend({
   acceptFileTypes: /(\.|\/)(gif|jpe?g|png|bmp|ico)$/i,
   maxFileSize: 50000000,
   loadImageMaxFileSize: 50000000,
-
+  maxChunkSize: null,
   // Fetch signature
   init() {
     this._super(...arguments);
@@ -47,7 +47,8 @@ export default Ember.Component.extend({
         imageMaxHeight:     this.get('imageMaxHeight'),
         acceptFileTypes:    this.get('acceptFileTypes'),
         maxFileSize:        this.get('maxFileSize'),
-        loadImageMaxFileSize: this.get('loadImageMaxFileSize')
+        loadImageMaxFileSize: this.get('loadImageMaxFileSize'),
+        maxChunkSize: this.get('maxChunkSize'),
       });
     });
   }),


### PR DESCRIPTION
Any files that are larger than 100MB are required to use chunk upload.
https://cloudinary.com/documentation/upload_images#chunked_image_upload
https://github.com/blueimp/jQuery-File-Upload/wiki/Chunked-file-uploads
https://github.com/blueimp/jQuery-File-Upload/blob/master/js/jquery.fileupload.js#L151